### PR TITLE
Avoid matching final column; only match warnings when margin > 0

### DIFF
--- a/plugin/longlines.vim
+++ b/plugin/longlines.vim
@@ -113,8 +113,10 @@ function! s:LongLines()
     endif
     if &textwidth > 0 && g:longlines_enabled != 0 && w:longlines_enabled != 0
       if len(w:LongLinesIds) == 0
-        let w:LongLinesIds += [ matchadd('LongLinesWarning',  '\%>' . &textwidth . 'v.*\%<' . (&textwidth + g:longlines_margin + 1) . 'v') ]
-        let w:LongLinesIds += [ matchadd('LongLinesError',    '\%>' . (&textwidth + g:longlines_margin) . 'v.*') ]
+        if g:longlines_margin > 0
+          let w:LongLinesIds += [ matchadd('LongLinesWarning',  '.\%>' . (&textwidth + 1) . 'v.*\%<' . (&textwidth + g:longlines_margin + 2) . 'v') ]
+        endif
+        let w:LongLinesIds += [ matchadd('LongLinesError',    '.\%>' . (&textwidth + g:longlines_margin + 1) . 'v.*') ]
       endif
     else
       if len(w:LongLinesIds) != 0


### PR DESCRIPTION
When a line is exactly `textwidth` characters long (80 for me), the blank column after it is highlighted despite no character being present in that column. The last column is highlighted even for typical matches, although this is less jarring.

This change modifies the logic to require a character to start any match which forces Vim to exclude the final column in both cases. Also, we avoid matching warnings as there is no reason to when `g:longlines_margin` is set to 0.